### PR TITLE
fix(koda): 백야 brand gemini->claude - Issue #102 429 완화

### DIFF
--- a/.github/scripts/team_discuss.py
+++ b/.github/scripts/team_discuss.py
@@ -91,7 +91,7 @@ AGENTS = [
         "id":    "baekya",
         "name":  "백야",
         "emoji": "🌙",
-        "brand": "gemini",
+        "brand": "claude",
         "role":  "객원 연구원 (Google 생태계)",
         "perspective": "외부 연구·Google AI 생태계 관점",
         "system": (


### PR DESCRIPTION
## Summary
- Issue #102: team_discuss.py 실행 시 Malu와 백야가 동시에 `brand: "gemini"`라서 동일한 `GEMINI_API_KEY` 쿼터를 공유, 두 에이전트가 동시에 HTTP 429를 맞는 현상이 발생.
- 백야를 `brand: "claude"`로 전환 (Kbin/RyuWon과 동일 경로) -> Gemini 호출량 절반으로 감소.

## Analysis
- Aurora 코칭 지시서(trang-to-koda-429-aurora-retry-directive-20260612.md)의 Option A(trend_cache.py에 Gemini 429 방어 로직 추가)는 전제가 맞지 않음 - trend_cache.py는 Gemini를 호출하지 않고 Google Trends API만 호출함. 따라서 미적용.
- 실제 원인은 Gemini API 키 쿼터 공유로 추정 (Malu + 백야 동시 429, 각각 풀 재시도(96s+) 후 실패).
- 이번 변경은 빠른 완화책. 근본적으로는 team_discuss.py의 call_gemini/call_claude 재시도 로직을 공통 유틸로 통합하는 후속 작업을 고려할 수 있음.

## Test plan
- [ ] 머지 후 다음 team-discussion-trigger.yml 실행에서 백야가 Claude API로 응답하는지 확인
- [ ] 429 에러 재발 여부 모니터링 (Issue #102)

Generated with Claude Code
