### PR TITLE
refactor(koda): Issue #102 — Gemini 429 재시도 공통 유틸 분리

### DIFF
--- a/.github/scripts/llm_retry_utils.py
+++ b/.github/scripts/llm_retry_utils.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+llm_retry_utils.py — LLM API 429 재시도 공통 유틸
+====================================================
+Issue #102 후속 과제: team_discuss.py의 call_gemini에 박혀있던
+429 방어 로직(presleep + 백오프)을 공통 유틸로 추출.
+
+Aurora (Colab Agent) 코칭 기준 — 호출 전 3.5초 쿨타임 적용.
+향후 다른 LLM 브랜드(DeepSeek 등) 추가 시에도 재사용 가능.
+
+작성: Koda (2026-06-15)
+"""
+
+import time
+import urllib.error
+
+PRESLEEP_SECONDS = 3.5
+DEFAULT_RETRY_AFTER = 30
+
+
+def call_with_429_retry(request_fn, agent_name: str = "", max_retries: int = 3):
+    """429(rate limit)에 대해 presleep + Retry-After 기반 백오프로 request_fn을 재시도한다.
+
+    request_fn: 인자 없이 호출되어 응답 텍스트를 반환하는 콜러블.
+                 urllib.error.HTTPError를 그대로 raise해야 한다.
+    """
+    for attempt in range(max_retries):
+        time.sleep(PRESLEEP_SECONDS)
+        try:
+            return request_fn()
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < max_retries - 1:
+                wait_time = int(e.headers.get("Retry-After", DEFAULT_RETRY_AFTER * (attempt + 1)))
+                print(f"[{agent_name}] 429 — {wait_time}초 후 재시도 ({attempt + 1}/{max_retries})")
+                time.sleep(wait_time)
+                continue
+            raise
+    raise RuntimeError(f"[{agent_name}] 429 재시도 한도 초과")

--- a/.github/scripts/team_discuss.py
+++ b/.github/scripts/team_discuss.py
@@ -29,6 +29,8 @@ import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 
+from llm_retry_utils import call_with_429_retry
+
 # ── 상수 ────────────────────────────────────────────────────────
 REPO = os.getenv("REPO_FULL", "wooriapt79/mulberry-research-lab")
 ISSUE_NUMBER = os.getenv("ISSUE_NUMBER", "")
@@ -193,7 +195,7 @@ def call_claude(agent: dict, prompt: str) -> str:
 
 
 def call_gemini(agent: dict, prompt: str) -> str:
-    """Gemini API 호출 — Malu"""
+    """Gemini API 호출 — Malu (429 방어: llm_retry_utils 공통 유틸 사용)"""
     url = (
         "https://generativelanguage.googleapis.com/v1beta/models/"
         f"gemini-2.0-flash:generateContent?key={GEMINI_KEY}"
@@ -207,21 +209,20 @@ def call_gemini(agent: dict, prompt: str) -> str:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    for attempt in range(3):
-        try:
-            time.sleep(3)
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                result = json.loads(resp.read().decode("utf-8"))
-                return result["candidates"][0]["content"]["parts"][0]["text"]
-        except urllib.error.HTTPError as e:
-            if e.code == 429 and attempt < 2:
-                print(f"[Malu] 429 — {(attempt+1)*30}초 후 재시도")
-                time.sleep((attempt + 1) * 30)
-                continue
-            return f"[{agent['name']}] Gemini 호출 오류 (HTTP {e.code})"
-        except Exception as e:
-            return f"[{agent['name']}] Gemini 호출 오류: {e}"
-    return "[Malu] 응답 생성 실패 — 잠시 후 다시 시도해 주세요."
+
+    def _request():
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+            return result["candidates"][0]["content"]["parts"][0]["text"]
+
+    try:
+        return call_with_429_retry(_request, agent_name=agent["name"])
+    except urllib.error.HTTPError as e:
+        return f"[{agent['name']}] Gemini 호출 오류 (HTTP {e.code})"
+    except RuntimeError:
+        return "[Malu] 응답 생성 실패 — 잠시 후 다시 시도해 주세요."
+    except Exception as e:
+        return f"[{agent['name']}] Gemini 호출 오류: {e}"
 
 
 def get_llm_response(agent: dict, prompt: str) -> str:


### PR DESCRIPTION
## 배경

Issue #102 (https://github.com/wooriapt79/mulberry-research-lab/issues/102) 후속 과제로 남겨둔 항목 처리:

> team_discuss.py의 call_gemini / call_claude 재시도 로직을 공통 유틸로 통합 고려

## 변경 사항

- 신규: `.github/scripts/llm_retry_utils.py` — `call_with_429_retry()` 공통 유틸
  - Aurora 코칭 기준 3.5초 presleep 적용
  - Retry-After 헤더 기반 백오프 (없으면 기본 30초 x 시도횟수)
  - 향후 DeepSeek 등 다른 브랜드 추가 시에도 재사용 가능
- `team_discuss.py`의 `call_gemini()`를 공통 유틸 사용으로 리팩터링 (기존 인라인 429 로직 제거)

## 테스트
- [x] `python -m py_compile` 통과
- [ ] 실제 team-discussion 라벨 트리거에서 동작 확인 (다음 실행 시)

🤖→👤 AI 대리 | CTO Koda | 2026-06-15