### PR TITLE
feat(koda): Issue #98 Phase 0 - Steward Decision Evaluator

### DIFF
--- a/configs/steward_decision_engine.yaml
+++ b/configs/steward_decision_engine.yaml
@@ -43,3 +43,13 @@ decision_rules:
     retry_max: 2
     backoff: exponential
     distillation_label: recovery
+  timeout_408:
+    condition: status == 408
+    action: HOLD
+    message: Request Timeout - needs human review
+    distillation_label: positive
+  ethics_block:
+    condition: spirit_score < 0.70
+    action: BLOCK
+    message: spirit_score below policy_ethics threshold
+    distillation_label: ethical_block

--- a/core/steward/steward_decision_evaluator.py
+++ b/core/steward/steward_decision_evaluator.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+Steward Decision Evaluator (Issue #98, Phase 0)
+
+Loads `configs/steward_decision_engine.yaml` and evaluates a request
+(HTTP status code + optional context, e.g. spirit_score) against the
+configured `decision_rules`, returning the action a Steward Agent should
+take.
+
+Replaces the previous hardcoded per-status-code branches scattered across
+`error_policy.yaml` consumers with a single config-driven evaluator -
+"문서 수정 -> YAML 갱신 -> 평가기가 그대로 반영" workflow.
+"""
+
+import operator
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+DEFAULT_CONFIG_PATH = Path("configs/steward_decision_engine.yaml")
+
+_OPERATORS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    "<=": operator.le,
+    ">": operator.gt,
+    "<": operator.lt,
+}
+
+# e.g. "status == 429" or "spirit_score < 0.70"
+_CONDITION_RE = re.compile(r"^(\w+)\s*(==|!=|>=|<=|>|<)\s*([\w.]+)$")
+
+
+def _coerce(value: str) -> Any:
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+class StewardDecisionEvaluator:
+    """Evaluates requests against `configs/steward_decision_engine.yaml`."""
+
+    def __init__(self, config_path: Optional[Path] = None):
+        self.config_path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+        self.config = self._load_config()
+        self.decision_rules = self.config.get("decision_rules", {})
+        self.evaluation_axes = self.config.get("evaluation_axes", {})
+
+    def _load_config(self) -> dict:
+        if not self.config_path.exists():
+            raise FileNotFoundError(f"steward decision config not found: {self.config_path}")
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+
+    @staticmethod
+    def _rule_matches(condition: str, facts: dict) -> bool:
+        match = _CONDITION_RE.match(condition.strip())
+        if not match:
+            return False
+        field, op_str, raw_value = match.groups()
+        if field not in facts or facts[field] is None:
+            return False
+        return _OPERATORS[op_str](facts[field], _coerce(raw_value))
+
+    def evaluate(self, status: int, context: Optional[dict] = None) -> dict:
+        """Evaluate a request and return the matching decision.
+
+        `facts` combines the HTTP `status` with any extra `context`
+        (e.g. `spirit_score`) and is checked against every rule's
+        `condition`. The first matching rule wins, in config order;
+        unmatched requests fall back to `action: ALLOW`.
+        """
+        facts = {"status": status, **(context or {})}
+
+        for name, rule in self.decision_rules.items():
+            condition = str(rule.get("condition", ""))
+            if self._rule_matches(condition, facts):
+                decision = dict(rule)
+                decision["name"] = name
+                decision["status"] = status
+                return decision
+
+        return {"action": "ALLOW", "name": None, "status": status}


### PR DESCRIPTION
## Summary
- Issue #98 (AI-SIEM Steward Console) Phase 0 착수: "core/steward_decision_evaluator.py 배치 및 로컬 검증" 항목 구현
- `core/steward/steward_decision_evaluator.py`: `configs/steward_decision_engine.yaml`의 `decision_rules`를 일반화된 `field op value` 조건(`status == 429`, `spirit_score < 0.70` 등)으로 평가하는 config-driven evaluator. 첫 매칭 규칙을 반환, 미매칭 시 `ALLOW`.
- `configs/steward_decision_engine.yaml`:
  - `timeout_408` 규칙 추가 (HOLD) — Phase 0 검증 기준("429/408/500/401 규칙 모두 정상 작동")의 408 케이스 보강
  - `ethics_block` 규칙 추가 (`spirit_score < 0.70` -> BLOCK) — Issue #98 Acceptance Criteria #1의 시나리오 충족

## Test plan
- [x] 로컬 검증: 429/401/500/502/503/408 -> 각각 REROUTE/BLOCK/RETRY/RETRY/RETRY/HOLD 확인
- [x] AC1 시나리오: `ethics_block.condition`을 `spirit_score < 0.70`으로 설정 후 `evaluate(200, {spirit_score: 0.69})` -> `BLOCK` 확인
- [ ] `api/routers/steward_router.py` (`/v1/siem/*`, `/v1/admin/metrics`)는 Phase 0 후속 작업으로 별도 진행

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>