### PR TITLE
fix(ci): repo-hygiene 게이트의 시크릿 패턴 오탐(false positive) 수정

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -49,7 +49,10 @@ jobs:
       - name: 🔍 치명적 위험 체크 (실패 조건)
         run: |
           # 하드코딩 시크릿 발견 시 실패
-          if grep -q "ghp_\|sk-\|Bearer.*=.*['\"]" hygiene_report.txt 2>/dev/null; then
+          # 주의: 단순 "sk-"/"ghp_" 문자열은 placeholder 예시 코드
+          # (예: "sk-여기에_새_키를_넣으세요")에도 등장하므로, 실제 키
+          # 형태(영숫자 20자 이상)만 치명적 위험으로 판단한다.
+          if grep -qE "ghp_[a-zA-Z0-9]{36}|sk-[a-zA-Z0-9]{20,}|Bearer [a-zA-Z0-9._-]{20,}" hygiene_report.txt 2>/dev/null; then
             echo "❌ 치명적 위험: 하드코딩 시크릿 발견"
             exit 1
           fi


### PR DESCRIPTION
## 배경
PR #111, #112가 모두 Repo Hygiene Check 실패로 머지가 차단되었습니다. 두 PR의 변경 파일 자체는 깨끗하며, 원인은 레포에 기존부터 있던 placeholder 예시 코드입니다.

- cookbook/pageindex_mcp_server_complete.py: API_KEY = "sk-여기에_새_키를_넣으세요"
- experiments/.../content-analyzer.py: openai_api_key="sk-your-api-key"

## 근본 원인
.github/workflows/repo-hygiene.yml 의 치명적 위험 게이트가 grep -q "ghp_|sk-|Bearer.*=.*['\"]" 로 너무 느슨합니다. 위생 점검 스크립트 2단계는 위 placeholder들을 경고로만 보고하는데, 이 보고서에 sk- 문자열이 한 글자라도 들어가면 게이트가 무조건 치명적 위험으로 처리해 빌드를 실패시킵니다. 즉 이 두 파일이 존재하는 한 앞으로의 모든 PR이 차단되는 구조적 버그입니다.

## 수정
게이트 패턴을 spirit_gate/checks/security.py 에 이미 있는 정밀 패턴과 동일하게 교체:

ghp_[a-zA-Z0-9]{36} | sk-[a-zA-Z0-9]{20,} | Bearer [a-zA-Z0-9._-]{20,}

- placeholder(sk-여기에_새_키를_넣으세요, sk-your-api-key)는 더 이상 매치되지 않음
- 실제 키 형태(sk- + 영숫자 20자 이상, ghp_ + 영숫자 36자)는 그대로 차단

## Test plan
- [x] scripts/repo_hygiene_check.sh 로컬 실행 -> 기존 게이트 패턴은 매치(실패), 신규 패턴은 매치 안 됨(통과) 확인
- [x] 실제 키 형태 문자열(sk-abcdefghijklmnopqrstuvwxyz123456)은 신규 패턴에도 매치되어 여전히 차단됨 확인
- [ ] 이 PR 머지 후 PR #111, #112 rebase하여 hygiene 통과 확인

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>