### PR TITLE
fix(workflow): sync-to-bank — ARG_MAX 초과 에러 수정 (Issue #119)

### DIFF
--- a/.github/workflows/sync-to-bank.yml
+++ b/.github/workflows/sync-to-bank.yml
@@ -21,9 +21,24 @@ jobs:
           ENTRY="\n## [LAB->Bank] ${{ github.event_name }} / $TIMESTAMP\n\n- Actor: ${{ github.actor }}\n- Issue: ${{ github.event.issue.title }}\n- URL: ${{ github.event.issue.html_url }}\n\n---\n"
           UPDATED="${CURRENT}${ENTRY}"
           ENCODED=$(printf "%s" "$UPDATED" | base64 -w 0)
+          # ARG_MAX 초과 방지: 페이로드를 파일로 저장 후 @파일 방식 사용 (Issue #119)
           if [ -n "$SHA" ]; then
-            curl -s -X PUT -H "Authorization: token $BANK_TOKEN" -H "Accept: application/vnd.github.v3+json" -H "Content-Type: application/json" -d "{\"message\":\"[LAB->Bank] activity synced\",\"content\":\"$ENCODED\",\"sha\":\"$SHA\"}" "https://api.github.com/repos/wooriapt79/mulberry_memory_bank/contents/agent_activity.md"
+            python3 -c "
+import json, sys
+payload = {'message': '[LAB->Bank] activity synced', 'content': sys.argv[1], 'sha': sys.argv[2]}
+print(json.dumps(payload))
+" "$ENCODED" "$SHA" > /tmp/bank_payload.json
           else
-            curl -s -X PUT -H "Authorization: token $BANK_TOKEN" -H "Accept: application/vnd.github.v3+json" -H "Content-Type: application/json" -d "{\"message\":\"[LAB->Bank] activity log initialized\",\"content\":\"$ENCODED\"}" "https://api.github.com/repos/wooriapt79/mulberry_memory_bank/contents/agent_activity.md"
+            python3 -c "
+import json, sys
+payload = {'message': '[LAB->Bank] activity log initialized', 'content': sys.argv[1]}
+print(json.dumps(payload))
+" "$ENCODED" > /tmp/bank_payload.json
           fi
+          curl -s -X PUT \
+            -H "Authorization: token $BANK_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/bank_payload.json \
+            "https://api.github.com/repos/wooriapt79/mulberry_memory_bank/contents/agent_activity.md"
           echo "Done - Bank agent_activity.md updated"


### PR DESCRIPTION
원인: curl -d 인자에 base64 인코딩된 agent_activity.md 전체를
      쉘 인자로 직접 삽입 → 파일이 커질수록 Linux ARG_MAX(~2MB) 초과
      → exit code 126

수정:
- python3으로 페이로드 JSON을 /tmp/bank_payload.json에 저장
- curl -d @/tmp/bank_payload.json 방식으로 전환
- SHA 유무에 따라 두 경로 모두 동일하게 처리

이제 agent_activity.md 크기와 무관하게 동작함.