### PR TITLE
fix(workflow): sync-to-bank YAML 구문 오류 수정 (Issue #119 follow-up)

### DIFF
--- a/.github/workflows/sync-to-bank.yml
+++ b/.github/workflows/sync-to-bank.yml
@@ -22,18 +22,11 @@ jobs:
           UPDATED="${CURRENT}${ENTRY}"
           ENCODED=$(printf "%s" "$UPDATED" | base64 -w 0)
           # ARG_MAX 초과 방지: 페이로드를 파일로 저장 후 @파일 방식 사용 (Issue #119)
+          # 한 줄 python3 -c 사용 — YAML run: | 블록 내 멀티라인 python -c 들여쓰기 오류 방지
           if [ -n "$SHA" ]; then
-            python3 -c "
-import json, sys
-payload = {'message': '[LAB->Bank] activity synced', 'content': sys.argv[1], 'sha': sys.argv[2]}
-print(json.dumps(payload))
-" "$ENCODED" "$SHA" > /tmp/bank_payload.json
+            python3 -c "import json,sys; print(json.dumps({'message':'[LAB->Bank] activity synced','content':sys.argv[1],'sha':sys.argv[2]}))" "$ENCODED" "$SHA" > /tmp/bank_payload.json
           else
-            python3 -c "
-import json, sys
-payload = {'message': '[LAB->Bank] activity log initialized', 'content': sys.argv[1]}
-print(json.dumps(payload))
-" "$ENCODED" > /tmp/bank_payload.json
+            python3 -c "import json,sys; print(json.dumps({'message':'[LAB->Bank] activity log initialized','content':sys.argv[1]}))" "$ENCODED" > /tmp/bank_payload.json
           fi
           curl -s -X PUT \
             -H "Authorization: token $BANK_TOKEN" \


### PR DESCRIPTION
멀티라인 python3 -c 블록의 들여쓰기 0 → YAML run: | 파서가
블록 종료로 판단하여 L27 YAML syntax error 발생.

수정: 두 python3 -c 호출을 모두 한 줄로 통합.
ARG_MAX 방지(@파일 방식)는 그대로 유지.